### PR TITLE
Allow override of provider sign-in logic

### DIFF
--- a/lib/any_login.rb
+++ b/lib/any_login.rb
@@ -21,6 +21,10 @@ module AnyLogin
   mattr_accessor :klass_name
   @@klass_name = 'User'
 
+  # Sign-in Method
+  mattr_accessor :sign_in
+  @@sign_in = nil
+
   # .all, .active, .admins, .groped_collection, etc ... need to return an array (or hash with arrays) of users
   mattr_accessor :collection_method
   @@collection_method = :all

--- a/lib/any_login/providers/devise.rb
+++ b/lib/any_login/providers/devise.rb
@@ -4,14 +4,21 @@ module AnyLogin
 
       module Controller
 
+        DEFAULT_SIGN_IN = proc do |loginable|
+          reset_session
+          sign_in AnyLogin.klass.to_s.underscore.to_sym, loginable
+        end
+
         def self.any_login_current_user_method
           @@any_login_current_user_method ||= "current_#{AnyLogin.klass.to_s.underscore}".to_sym
         end
 
         def any_login_sign_in
-          reset_session
           @loginable = AnyLogin.klass.find(params[:selected_id].presence || params[:id])
-          sign_in AnyLogin.klass.to_s.underscore.to_sym, @loginable
+
+          sign_in = AnyLogin.sign_in || DEFAULT_SIGN_IN
+          instance_exec(@loginable, &sign_in)
+
           redirect_to main_app.send(AnyLogin.redirect_path_after_login)
         end
 


### PR DESCRIPTION
Override the default sign in behavior of Devise (and later other providers) by configuring a `AnyLogin.sign_in` proc to execute. This is a proof of concept for further discussion about issue #14. 

## Example

```ruby
AnyLogin.setup do |config|
  config.sign_in = proc do |loginable|
    # Assume permissions of another user instead of logging in as that user
    current_admin_user.update_columns(assume_permissions_of_admin_user_id: loginable)
  end
end
```
