### PR TITLE
Prevent queries from being executed when calling `grouped?`

### DIFF
--- a/app/helpers/any_login/application_helper.rb
+++ b/app/helpers/any_login/application_helper.rb
@@ -19,10 +19,10 @@ module AnyLogin
       def any_login_select
         collection = AnyLogin.collection
         select_options =
-                        if AnyLogin.grouped?
-                          grouped_options_for_select(collection)
+                        if collection.grouped?
+                          grouped_options_for_select(collection.to_a)
                         else
-                          options_for_select(collection)
+                          options_for_select(collection.to_a)
                         end
         select_tag :selected_id, select_options, select_html_options
       end

--- a/lib/any_login.rb
+++ b/lib/any_login.rb
@@ -81,22 +81,8 @@ module AnyLogin
     yield(self)
   end
 
-  def self.grouped?
-    collection_type == :grouped
-  end
-
   def self.collection
-    collection_raw.collect do |e|
-      if grouped?
-        [e[0], e[1].collect(&name_method)]
-      else
-        if name_method.is_a?(Symbol)
-          e.send(name_method)
-        else
-          name_method.call(e)
-        end
-      end
-    end
+    Collection.new(collection_raw)
   end
 
   def self.klass
@@ -128,18 +114,9 @@ module AnyLogin
     end
   end
 
-  def self.collection_type
-    @@collection_type =
-                        if collection_raw[1].is_a?(Array)
-                          :grouped
-                        else
-                          :single
-                        end
-    @@collection_type
-  end
-
 end
 
+require 'any_login/collection'
 require 'any_login/engine'
 require 'any_login/routes'
 require 'any_login/version'

--- a/lib/any_login/collection.rb
+++ b/lib/any_login/collection.rb
@@ -1,0 +1,37 @@
+module AnyLogin
+  class Collection
+    attr_reader :collection_raw
+
+    def initialize(collection_raw)
+      @collection_raw = collection_raw
+    end
+
+    def grouped?
+      type == :grouped
+    end
+
+    def to_a
+      collection_raw.collect do |e|
+        if grouped?
+          [e[0], e[1].collect(&AnyLogin.name_method)]
+        else
+          if AnyLogin.name_method.is_a?(Symbol)
+            e.send(AnyLogin.name_method)
+          else
+            AnyLogin.name_method.call(e)
+          end
+        end
+      end
+    end
+
+    private
+
+    def type
+      @type ||= if collection_raw[0].is_a?(Array)
+                  :grouped
+                else
+                  :single
+                end
+    end
+  end
+end

--- a/test/any_login/collection_test.rb
+++ b/test/any_login/collection_test.rb
@@ -1,0 +1,75 @@
+require "test_helper"
+
+module AnyLogin
+  class CollectionTest < ActiveSupport::TestCase
+    FakeUser = Struct.new(:id, :email)
+
+    test "single collection should return false with the grouped?" do
+      single = [
+        FakeUser.new(1, "1@example.com"),
+        FakeUser.new(2, "2@example.com")
+      ]
+      collection = AnyLogin::Collection.new(single)
+
+      assert_equal false, collection.grouped?
+    end
+
+    test "single collection should returns an Array" do
+      begin
+        prev = AnyLogin.name_method
+
+        single = [
+          FakeUser.new(1, "1@example.com"),
+          FakeUser.new(2, "2@example.com")
+        ]
+        collection = AnyLogin::Collection.new(single)
+
+        AnyLogin.name_method = :email
+        assert_equal ["1@example.com", "2@example.com"], collection.to_a
+
+        AnyLogin.name_method = ->(e) { e.id }
+        assert_equal [1, 2], collection.to_a
+      rescue
+        AnyLogin.name_method = prev
+      end
+    end
+
+    test "grouped collection should return true with the grouped?" do
+      grouped = [
+        ["admin", [FakeUser.new(1, "1@example.com"), FakeUser.new(2, "2@example.com")]],
+        ["user",  [FakeUser.new(3, "3@example.com"), FakeUser.new(4, "4@example.com")]],
+      ]
+      collection = AnyLogin::Collection.new(grouped)
+
+      assert_equal true, collection.grouped?
+    end
+
+    test "grouped collection should returns an Array" do
+      begin
+        prev = AnyLogin.name_method
+
+        grouped = [
+          ["admin", [FakeUser.new(1, "1@example.com"), FakeUser.new(2, "2@example.com")]],
+          ["user",  [FakeUser.new(3, "3@example.com"), FakeUser.new(4, "4@example.com")]],
+        ]
+        collection = AnyLogin::Collection.new(grouped)
+
+        AnyLogin.name_method = :email
+        expected = [
+          ["admin", ["1@example.com", "2@example.com"]],
+          ["user", ["3@example.com", "4@example.com"]]
+        ]
+        assert_equal expected, collection.to_a
+
+        AnyLogin.name_method = ->(e) { e.id }
+        expected = [
+          ["admin", [1, 2]],
+          ["user", [3, 4]]
+        ]
+        assert_equal expected, collection.to_a
+      rescue
+        AnyLogin.name_method = prev
+      end
+    end
+  end
+end


### PR DESCRIPTION
before:

```
[1] pry(main)> AnyLogin.collection
  User Load (0.8ms)  SELECT  `users`.* FROM `users` LIMIT 10
  User Load (1.0ms)  SELECT  `users`.* FROM `users` LIMIT 10
  User Load (0.8ms)  SELECT  `users`.* FROM `users` LIMIT 10
  User Load (0.9ms)  SELECT  `users`.* FROM `users` LIMIT 10
  User Load (0.8ms)  SELECT  `users`.* FROM `users` LIMIT 10
  User Load (5.8ms)  SELECT  `users`.* FROM `users` LIMIT 10
  User Load (0.9ms)  SELECT  `users`.* FROM `users` LIMIT 10
  User Load (2.2ms)  SELECT  `users`.* FROM `users` LIMIT 10
  User Load (1.9ms)  SELECT  `users`.* FROM `users` LIMIT 10
  User Load (2.2ms)  SELECT  `users`.* FROM `users` LIMIT 10
  User Load (1.1ms)  SELECT  `users`.* FROM `users` LIMIT 10
=> [["user_1@example.com", 1],
 ["user_2@example.com", 2],
 ["user_3@example.com", 3],
 ["user_4@example.com", 4],
 ["user_5@example.com", 5],
 ["user_6@example.com", 6],
 ["user_7@example.com", 7],
 ["user_8@example.com", 8],
 ["user_9@example.com", 9],
 ["user_10@example.com", 10]]
```

after:

```
[1] pry(main)> collection = AnyLogin.collection
  User Load (0.9ms)  SELECT  `users`.* FROM `users` LIMIT 10
=> #<AnyLogin::Collection:0x007fc95bd73ad0
 @collection_raw=
....
[2] pry(main)> collection.to_a
=> [["user_1@example.com", 1],
 ["user_2@example.com", 2],
 ["user_3@example.com", 3],
 ["user_4@example.com", 4],
 ["user_5@example.com", 5],
 ["user_6@example.com", 6],
 ["user_7@example.com", 7],
 ["user_8@example.com", 8],
 ["user_9@example.com", 9],
 ["user_10@example.com", 10]]