### PR TITLE
Parameterize before Underscore

### DIFF
--- a/lib/any_login/providers/authlogic.rb
+++ b/lib/any_login/providers/authlogic.rb
@@ -5,7 +5,7 @@ module AnyLogin
       module Controller
 
         def self.any_login_current_user_method
-          @@any_login_current_user_method ||= "current_#{AnyLogin.klass.to_s.underscore}".to_sym
+          @@any_login_current_user_method ||= "current_#{AnyLogin.klass.to_s.parameterize.underscore}".to_sym
         end
 
         def any_login_sign_in

--- a/lib/any_login/providers/clearance.rb
+++ b/lib/any_login/providers/clearance.rb
@@ -5,7 +5,7 @@ module AnyLogin
       module Controller
 
         def self.any_login_current_user_method
-          @@any_login_current_user_method ||= "current_#{AnyLogin.klass.to_s.underscore}".to_sym
+          @@any_login_current_user_method ||= "current_#{AnyLogin.klass.to_s.parameterize.underscore}".to_sym
         end
 
         def any_login_sign_in

--- a/lib/any_login/providers/devise.rb
+++ b/lib/any_login/providers/devise.rb
@@ -6,11 +6,11 @@ module AnyLogin
 
         DEFAULT_SIGN_IN = proc do |loginable|
           reset_session
-          sign_in AnyLogin.klass.to_s.underscore.to_sym, loginable
+          sign_in AnyLogin.klass.to_s.parameterize.underscore.to_sym, loginable
         end
 
         def self.any_login_current_user_method
-          @@any_login_current_user_method ||= "current_#{AnyLogin.klass.to_s.underscore}".to_sym
+          @@any_login_current_user_method ||= "current_#{AnyLogin.klass.to_s.parameterize.underscore}".to_sym
         end
 
         def any_login_sign_in

--- a/lib/any_login/providers/sorcery.rb
+++ b/lib/any_login/providers/sorcery.rb
@@ -5,7 +5,7 @@ module AnyLogin
       module Controller
 
         def self.any_login_current_user_method
-          @@any_login_current_user_method ||= "current_#{AnyLogin.klass.to_s.underscore}".to_sym
+          @@any_login_current_user_method ||= "current_#{AnyLogin.klass.to_s.parameterize.underscore}".to_sym
         end
 
         def any_login_sign_in


### PR DESCRIPTION
Without "parameterizing" the string, if the user class is namespaced like `Spree::User`, it will interpolate to `current_spree/user`.

Using `parameterize` before `underscore` will properly interpolate the string to `current_spree_user`.