### PR TITLE
Test with Ruby 2.7 and 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: ruby
 
 rvm:
-  - "2.5.3"
-  - "2.6.3"
+  - 2.5
+  - 2.6
+  - 2.7
+  - 3.0
 
 before_install: gem install bundler
 


### PR DESCRIPTION
This should also test the latest patch versions of Ruby available on Travis CI.

Btw, since this gem supports Ruby 1.9.3 and above, should we try to test older versions as well?