### PR TITLE
fix device login key

### DIFF
--- a/lib/any_login/providers/devise.rb
+++ b/lib/any_login/providers/devise.rb
@@ -6,11 +6,15 @@ module AnyLogin
 
         DEFAULT_SIGN_IN = proc do |loginable|
           reset_session
-          sign_in AnyLogin.klass.to_s.parameterize.underscore.to_sym, loginable
+          sign_in Controller.mapping_key, loginable
         end
 
         def self.any_login_current_user_method
-          @@any_login_current_user_method ||= "current_#{AnyLogin.klass.to_s.parameterize.underscore}".to_sym
+          @@any_login_current_user_method ||= "current_#{mapping_key}".to_sym
+        end
+
+        def self.mapping_key
+          @@mapping_key ||= ::Devise.mappings.detect {|_key, mapping| mapping.class_name == AnyLogin.klass.name }.first
         end
 
         def any_login_sign_in
@@ -21,7 +25,6 @@ module AnyLogin
 
           redirect_to main_app.send(AnyLogin.redirect_path_after_login)
         end
-
       end
 
     end


### PR DESCRIPTION
We use the AdminUser model
Currently, any_login_current_user_method is `:adminuser`, but the key defined by the device is `:admin_user`.

In this PR, the key is changed to directly specify the key defined by the device, without using parameterize or underscore