### PR TITLE
Remove enable-background directive from user SVG

### DIFF
--- a/app/views/any_login/svg/_user.html.erb
+++ b/app/views/any_login/svg/_user.html.erb
@@ -1,6 +1,5 @@
 <?xml version="1.0" ?>
-<svg style="enable-background:new 0 0 24 24;" version="1.1" viewBox="0 0 24 24" height="16" width="16" role="img"
-  xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg version="1.1" viewBox="0 0 24 24" height="16" width="16" role="img" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title><%= title %></title>
   <g id="info" />
   <g id="icons">


### PR DESCRIPTION
The `enable-background` directive [doesn't really do anything](https://stackoverflow.com/questions/21354116/what-exactly-does-the-enable-background-attribute-do) and causes an error when a content security policy is enabled:

<img width="734" alt="Screenshot 2023-03-23 at 2 11 44 PM" src="https://user-images.githubusercontent.com/2308869/227307085-3a2297e4-3b9c-451f-8db8-4d45674eeed9.png">

Removing it doesn't change the behavior, it just clears an error off the console.